### PR TITLE
FCM 푸시 알림 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
 
 	// web_hook
 	implementation(Dependencies.OK_HTTP)
+
+	// fcm
+	implementation(Dependencies.FCM)
 }
 
 tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,4 +31,7 @@ object Dependencies {
 
     // web_hook
     const val OK_HTTP = "com.squareup.okhttp3:okhttp:${DependencyVersions.OK_HTTP_VERSION}"
+
+    // fcm
+    const val FCM = "com.google.firebase:firebase-admin:${DependencyVersions.FCM_VERSION}"
 }

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -17,4 +17,7 @@ object DependencyVersions {
 
     // web_hook
     const val OK_HTTP_VERSION = "4.10.0"
+
+    // fcm
+    const val FCM_VERSION = "9.1.1"
 }

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/presentation/InquiryController.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/presentation/InquiryController.kt
@@ -4,6 +4,7 @@ import andreas311.miso.domain.inquiry.presentation.data.request.WriteInquiryRequ
 import andreas311.miso.domain.inquiry.presentation.data.response.DetailInquiryResponseDto
 import andreas311.miso.domain.inquiry.presentation.data.response.ListInquiryResponseDto
 import andreas311.miso.domain.inquiry.service.*
+import andreas311.miso.domain.notification.presentation.data.request.WriteNotificationRequestDto
 import andreas311.miso.global.annotation.RequestController
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.multipart.MultipartFile
 
@@ -48,13 +50,12 @@ class InquiryController(
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 
     @PatchMapping("/adopt/{id}")
-    fun adopt(@PathVariable id: Long): ResponseEntity<Void> =
-        adoptInquiryService.execute(id)
+    fun adopt(@PathVariable id: Long, @RequestBody writeNotificationRequestDto: WriteNotificationRequestDto): ResponseEntity<Void> =
+        adoptInquiryService.execute(id, writeNotificationRequestDto)
             .let { ResponseEntity.status(HttpStatus.OK).build() }
 
     @PatchMapping("/unadopt/{id}")
-    fun unAdopt(@PathVariable id: Long): ResponseEntity<Void> =
-        unAdoptInquiryService.execute(id)
+    fun unAdopt(@PathVariable id: Long, @RequestBody writeNotificationRequestDto: WriteNotificationRequestDto): ResponseEntity<Void> =
+        unAdoptInquiryService.execute(id, writeNotificationRequestDto)
             .let { ResponseEntity.status(HttpStatus.OK).build() }
-
 }

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/AdoptInquiryService.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/AdoptInquiryService.kt
@@ -1,6 +1,9 @@
 package andreas311.miso.domain.inquiry.service
 
+import andreas311.miso.domain.notification.entity.Notification
+import andreas311.miso.domain.notification.presentation.data.request.WriteNotificationRequestDto
+
 interface AdoptInquiryService {
 
-    fun execute(id: Long)
+    fun execute(id: Long, writeNotificationRequestDto: WriteNotificationRequestDto): Notification
 }

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/UnAdoptInquiryService.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/UnAdoptInquiryService.kt
@@ -1,6 +1,9 @@
 package andreas311.miso.domain.inquiry.service
 
+import andreas311.miso.domain.notification.entity.Notification
+import andreas311.miso.domain.notification.presentation.data.request.WriteNotificationRequestDto
+
 interface UnAdoptInquiryService {
 
-    fun execute(id: Long)
+    fun execute(id: Long, writeNotificationRequestDto: WriteNotificationRequestDto): Notification
 }

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/AdoptInquiryServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/AdoptInquiryServiceImpl.kt
@@ -1,23 +1,61 @@
 package andreas311.miso.domain.inquiry.service.impl
 
+import andreas311.miso.domain.inquiry.entity.Inquiry
 import andreas311.miso.domain.inquiry.enums.InquiryStatus
 import andreas311.miso.domain.inquiry.exception.InquiryNotFoundException
 import andreas311.miso.domain.inquiry.repository.InquiryRepository
 import andreas311.miso.domain.inquiry.service.AdoptInquiryService
+import andreas311.miso.domain.notification.entity.Notification
+import andreas311.miso.domain.notification.presentation.data.dto.WriteNotificationDto
+import andreas311.miso.domain.notification.presentation.data.request.WriteNotificationRequestDto
+import andreas311.miso.domain.notification.repository.DeviceTokenRepository
+import andreas311.miso.domain.notification.service.NotificationSendService
+import andreas311.miso.domain.notification.util.NotificationUtil
+import andreas311.miso.domain.user.entity.User
 import andreas311.miso.global.annotation.RollbackService
+import andreas311.miso.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 
 @RollbackService
 class AdoptInquiryServiceImpl(
-    private val inquiryRepository: InquiryRepository
+    private val userUtil: UserUtil,
+    private val notificationUtil: NotificationUtil,
+    private val inquiryRepository: InquiryRepository,
+    private val deviceTokenRepository: DeviceTokenRepository,
+    private val notificationSendService: NotificationSendService
 ) : AdoptInquiryService {
 
-    override fun execute(id: Long) {
+    override fun execute(id: Long, writeNotificationRequestDto: WriteNotificationRequestDto): Notification {
+
+        val user = userUtil.currentUser()
+
+        val writeNotificationDto: WriteNotificationDto = toDto(writeNotificationRequestDto = writeNotificationRequestDto)
 
         val inquiry = inquiryRepository.findByIdOrNull(id)
             ?: throw InquiryNotFoundException()
 
         inquiry.updateInquiryStatus(InquiryStatus.ADOPT)
+
+        val token = deviceTokenRepository.findByUser(user)
+
+        token?.let { notificationSendService.execute(inquiry, token.token)}
+
+        return toEntity(writeNotificationDto, user, inquiry)
+            .let { notificationUtil.saveNotification(notification = it) }
     }
 
+    private fun toEntity(writeNotificationDto: WriteNotificationDto, user: User, inquiry: Inquiry): Notification =
+        Notification(
+            id = 0L,
+            title = writeNotificationDto.title,
+            content = writeNotificationDto.content,
+            user = user,
+            inquiry = inquiry
+        )
+
+    private fun toDto(writeNotificationRequestDto: WriteNotificationRequestDto): WriteNotificationDto =
+        WriteNotificationDto(
+            title = writeNotificationRequestDto.title,
+            content = writeNotificationRequestDto.content
+        )
 }

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/UnAdoptInquiryServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/UnAdoptInquiryServiceImpl.kt
@@ -1,22 +1,61 @@
 package andreas311.miso.domain.inquiry.service.impl
 
+import andreas311.miso.domain.inquiry.entity.Inquiry
 import andreas311.miso.domain.inquiry.enums.InquiryStatus
 import andreas311.miso.domain.inquiry.exception.InquiryNotFoundException
 import andreas311.miso.domain.inquiry.repository.InquiryRepository
 import andreas311.miso.domain.inquiry.service.UnAdoptInquiryService
+import andreas311.miso.domain.notification.entity.Notification
+import andreas311.miso.domain.notification.presentation.data.dto.WriteNotificationDto
+import andreas311.miso.domain.notification.presentation.data.request.WriteNotificationRequestDto
+import andreas311.miso.domain.notification.repository.DeviceTokenRepository
+import andreas311.miso.domain.notification.service.NotificationSendService
+import andreas311.miso.domain.notification.util.NotificationUtil
+import andreas311.miso.domain.user.entity.User
 import andreas311.miso.global.annotation.RollbackService
+import andreas311.miso.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 
 @RollbackService
 class UnAdoptInquiryServiceImpl(
-    private val inquiryRepository: InquiryRepository
+    private val userUtil: UserUtil,
+    private val notificationUtil: NotificationUtil,
+    private val inquiryRepository: InquiryRepository,
+    private val deviceTokenRepository: DeviceTokenRepository,
+    private val notificationSendService: NotificationSendService
 ) : UnAdoptInquiryService {
 
-    override fun execute(id: Long) {
+    override fun execute(id: Long, writeNotificationRequestDto: WriteNotificationRequestDto): Notification {
+
+        val user = userUtil.currentUser()
+
+        val writeNotificationDto: WriteNotificationDto = toDto(writeNotificationRequestDto = writeNotificationRequestDto)
 
         val inquiry = inquiryRepository.findByIdOrNull(id)
             ?: throw InquiryNotFoundException()
 
         inquiry.updateInquiryStatus(InquiryStatus.UNADOPT)
+
+        val token = deviceTokenRepository.findByUser(user)
+
+        token?.let { notificationSendService.execute(inquiry, it.token) }
+
+        return toEntity(writeNotificationDto, user, inquiry)
+            .let { notificationUtil.saveNotification(notification = it) }
     }
+
+    private fun toEntity(writeNotificationDto: WriteNotificationDto, user: User, inquiry: Inquiry): Notification =
+        Notification(
+            id = 0L,
+            title = writeNotificationDto.title,
+            content = writeNotificationDto.content,
+            user = user,
+            inquiry = inquiry
+        )
+
+    private fun toDto(writeNotificationRequestDto: WriteNotificationRequestDto): WriteNotificationDto =
+        WriteNotificationDto(
+            title = writeNotificationRequestDto.title,
+            content = writeNotificationRequestDto.content
+        )
 }

--- a/src/main/kotlin/andreas311/miso/domain/notification/entity/DeviceToken.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/entity/DeviceToken.kt
@@ -1,0 +1,26 @@
+package andreas311.miso.domain.notification.entity
+
+import andreas311.miso.domain.user.entity.User
+import org.hibernate.annotations.DynamicUpdate
+import javax.persistence.*
+
+@Entity
+@DynamicUpdate
+class DeviceToken (
+
+    @Id
+    @Column(name = "device_token_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    var token: String,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: User
+) {
+
+    fun updateDeviceToken(token: String) {
+        this.token = token
+    }
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/entity/Notification.kt
@@ -1,0 +1,30 @@
+package andreas311.miso.domain.notification.entity
+
+import andreas311.miso.domain.inquiry.entity.Inquiry
+import andreas311.miso.domain.user.entity.User
+import org.hibernate.annotations.DynamicUpdate
+import javax.persistence.*
+
+@Entity
+@DynamicUpdate
+class Notification(
+
+    @Id
+    @Column(name = "notification_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Column(name = "title")
+    val title: String,
+
+    @Column(name = "content")
+    val content: String,
+
+    @ManyToOne
+    @JoinColumn(name = "inquiry_id")
+    val inquiry: Inquiry,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: User
+)

--- a/src/main/kotlin/andreas311/miso/domain/notification/entity/data/NotificationAlarm.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/entity/data/NotificationAlarm.kt
@@ -1,0 +1,7 @@
+package andreas311.miso.domain.notification.entity.data
+
+data class NotificationAlarm(
+    val title: String,
+    val content: String,
+    val writer: String
+)

--- a/src/main/kotlin/andreas311/miso/domain/notification/enums/NotificationType.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/enums/NotificationType.kt
@@ -1,0 +1,22 @@
+package andreas311.miso.domain.notification.enums
+
+enum class NotificationType(
+    val title: String,
+    val content: String
+) {
+
+    INQUIRT_WAIT(
+        title = "MISO 문의사항 등록 완료!",
+        content = "최대한 빠르게 답변 드릴테니 기다려주세요 :)"
+    ),
+
+    INQUIRY_ADOPT(
+        title = "MISO 문의사항 채택 완료!",
+        content = "자세한 사항은 앱에서 확인해주세요 :)"
+    ),
+
+    INQUIRY_UNADOPT(
+        title = "MISO 문의사항 비채택..",
+        content = "자세한 사항은 앱에서 확인해주세요 :("
+    ),
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/presentation/NotificationController.kt
@@ -1,0 +1,19 @@
+package andreas311.miso.domain.notification.presentation
+
+import andreas311.miso.domain.notification.service.SaveDeviceTokenService
+import andreas311.miso.global.annotation.RequestController
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+
+@RequestController("/notification")
+class NotificationController(
+    private val saveDeviceTokenService: SaveDeviceTokenService
+) {
+
+    @PostMapping("/save/{deviceToken}")
+    fun save(@PathVariable deviceToken: String): ResponseEntity<Void> =
+        saveDeviceTokenService.execute(deviceToken)
+            .let { ResponseEntity.status(HttpStatus.CREATED).build() }
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/presentation/data/dto/WriteNotificationDto.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/presentation/data/dto/WriteNotificationDto.kt
@@ -1,0 +1,6 @@
+package andreas311.miso.domain.notification.presentation.data.dto
+
+data class WriteNotificationDto(
+    val title: String,
+    val content: String
+)

--- a/src/main/kotlin/andreas311/miso/domain/notification/presentation/data/request/WriteNotificationRequestDto.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/presentation/data/request/WriteNotificationRequestDto.kt
@@ -1,0 +1,6 @@
+package andreas311.miso.domain.notification.presentation.data.request
+
+data class WriteNotificationRequestDto(
+    val title: String,
+    val content: String
+)

--- a/src/main/kotlin/andreas311/miso/domain/notification/repository/DeviceTokenRepository.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/repository/DeviceTokenRepository.kt
@@ -1,0 +1,10 @@
+package andreas311.miso.domain.notification.repository
+
+import andreas311.miso.domain.notification.entity.DeviceToken
+import andreas311.miso.domain.user.entity.User
+import org.springframework.data.repository.CrudRepository
+
+interface DeviceTokenRepository : CrudRepository<DeviceToken, Long> {
+
+    fun findByUser(user: User): DeviceToken?
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/repository/NotificationRepository.kt
@@ -1,0 +1,7 @@
+package andreas311.miso.domain.notification.repository
+
+import andreas311.miso.domain.notification.entity.Notification
+import org.springframework.data.repository.CrudRepository
+
+interface NotificationRepository : CrudRepository<Notification, Long> {
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/service/NotificationSendService.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/service/NotificationSendService.kt
@@ -1,0 +1,8 @@
+package andreas311.miso.domain.notification.service
+
+import andreas311.miso.domain.inquiry.entity.Inquiry
+
+interface NotificationSendService {
+
+    fun execute(inquiry: Inquiry, token: String)
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/service/SaveDeviceTokenService.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/service/SaveDeviceTokenService.kt
@@ -1,0 +1,6 @@
+package andreas311.miso.domain.notification.service
+
+interface SaveDeviceTokenService {
+
+    fun execute(token: String)
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/service/impl/NotificationSendServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/service/impl/NotificationSendServiceImpl.kt
@@ -1,0 +1,37 @@
+package andreas311.miso.domain.notification.service.impl
+
+import andreas311.miso.domain.inquiry.entity.Inquiry
+import andreas311.miso.domain.inquiry.enums.InquiryStatus
+import andreas311.miso.domain.notification.entity.data.NotificationAlarm
+import andreas311.miso.domain.notification.enums.NotificationType
+import andreas311.miso.domain.notification.service.NotificationSendService
+import andreas311.miso.global.annotation.RollbackService
+import andreas311.miso.global.util.FcmUtil
+
+@RollbackService
+class NotificationSendServiceImpl(
+    private val fcmUtil: FcmUtil,
+) : NotificationSendService {
+
+    override fun execute(inquiry: Inquiry, token: String) {
+        val notificationType = when (inquiry.inquiryStatus) {
+            InquiryStatus.ADOPT -> NotificationType.INQUIRY_ADOPT
+            InquiryStatus.UNADOPT -> NotificationType.INQUIRY_UNADOPT
+            InquiryStatus.WAIT -> NotificationType.INQUIRT_WAIT
+        }
+
+        runCatching {
+            fcmUtil.sendNotification(
+                deviceToken = token,
+                notificationAlarm = NotificationAlarm(
+                    title = notificationType.title,
+                    content = notificationType.content,
+                    writer = "미소"
+                )
+            )
+
+        }.onFailure {
+            it.printStackTrace()
+        }
+    }
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/service/impl/SaveDeviceTokenServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/service/impl/SaveDeviceTokenServiceImpl.kt
@@ -1,0 +1,33 @@
+package andreas311.miso.domain.notification.service.impl
+
+import andreas311.miso.domain.notification.entity.DeviceToken
+import andreas311.miso.domain.notification.repository.DeviceTokenRepository
+import andreas311.miso.domain.notification.service.SaveDeviceTokenService
+import andreas311.miso.global.annotation.RollbackService
+import andreas311.miso.global.util.UserUtil
+
+@RollbackService
+class SaveDeviceTokenServiceImpl(
+    private val userUtil: UserUtil,
+    private val deviceTokenRepository: DeviceTokenRepository
+) : SaveDeviceTokenService {
+
+    override fun execute(token: String) {
+
+        val user = userUtil.currentUser()
+
+        val deviceToken = deviceTokenRepository.findByUser(user)
+
+        if (deviceToken == null) {
+            deviceTokenRepository.save(
+                DeviceToken(
+                    id = 0L,
+                    token = token,
+                    user = user
+                )
+            )
+        } else {
+            deviceToken.updateDeviceToken(token)
+        }
+    }
+}

--- a/src/main/kotlin/andreas311/miso/domain/notification/util/NotificationUtil.kt
+++ b/src/main/kotlin/andreas311/miso/domain/notification/util/NotificationUtil.kt
@@ -1,0 +1,14 @@
+package andreas311.miso.domain.notification.util
+
+import andreas311.miso.domain.notification.entity.Notification
+import andreas311.miso.domain.notification.repository.NotificationRepository
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationUtil(
+    private val notificationRepository: NotificationRepository
+) {
+
+    fun saveNotification(notification: Notification) =
+        notificationRepository.save(notification)
+}

--- a/src/main/kotlin/andreas311/miso/domain/recyclables/service/impl/ProcessRecyclablesImageServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/recyclables/service/impl/ProcessRecyclablesImageServiceImpl.kt
@@ -20,7 +20,7 @@ class ProcessRecyclablesImageServiceImpl(
     private val recyclablesRepository: RecyclablesRepository
 ) : ProcessRecyclablesImageService {
 
-    @Value("\${secret-url}")
+    @Value("\${ai.url}")
     private val url: String = ""
 
     override fun execute(multipartFile: MultipartFile): ListDetailRecyclablesResponseDto {

--- a/src/main/kotlin/andreas311/miso/global/config/ConfigurationPropertiesScanConfig.kt
+++ b/src/main/kotlin/andreas311/miso/global/config/ConfigurationPropertiesScanConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConfigurationPropertiesScan(basePackages =
-["andreas311.miso.global.redis.properties",
-"andreas311.miso.global.security.jwt.properties"])
+["andreas311.miso.global.config.redis.properties",
+"andreas311.miso.global.security.jwt.properties",
+"andreas311.miso.global.config.notification.properties"])
 class ConfigurationPropertiesScanConfig

--- a/src/main/kotlin/andreas311/miso/global/config/notification/FcmConfig.kt
+++ b/src/main/kotlin/andreas311/miso/global/config/notification/FcmConfig.kt
@@ -1,0 +1,42 @@
+package andreas311.miso.global.config.notification
+
+import andreas311.miso.global.config.notification.properties.FcmProperties
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import org.springframework.context.annotation.Configuration
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import javax.annotation.PostConstruct
+
+@Configuration
+class FcmConfig(
+    private val fcmProperties: FcmProperties
+) {
+
+    companion object {
+        const val PATH = "./credentials.json"
+    }
+
+    @PostConstruct
+    fun init() {
+        runCatching {
+            URL(fcmProperties.url).openStream().use {
+                Files.copy(it, Paths.get(PATH))
+                val file = File(PATH)
+                if (FirebaseApp.getApps().isEmpty()) {
+                    val options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(file.inputStream()))
+                        .build()
+                    FirebaseApp.initializeApp(options)
+                }
+                file.delete()
+            }
+        }.onFailure {
+            it.printStackTrace()
+        }
+    }
+
+}

--- a/src/main/kotlin/andreas311/miso/global/config/notification/properties/FcmProperties.kt
+++ b/src/main/kotlin/andreas311/miso/global/config/notification/properties/FcmProperties.kt
@@ -1,0 +1,10 @@
+package andreas311.miso.global.config.notification.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "fcm")
+class FcmProperties(
+    val url: String
+)

--- a/src/main/kotlin/andreas311/miso/global/config/redis/RedisConfig.kt
+++ b/src/main/kotlin/andreas311/miso/global/config/redis/RedisConfig.kt
@@ -1,6 +1,6 @@
-package andreas311.miso.global.redis
+package andreas311.miso.global.config.redis
 
-import andreas311.miso.global.redis.properties.RedisProperties
+import andreas311.miso.global.config.redis.properties.RedisProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory

--- a/src/main/kotlin/andreas311/miso/global/config/redis/properties/RedisProperties.kt
+++ b/src/main/kotlin/andreas311/miso/global/config/redis/properties/RedisProperties.kt
@@ -1,4 +1,4 @@
-package andreas311.miso.global.redis.properties
+package andreas311.miso.global.config.redis.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding

--- a/src/main/kotlin/andreas311/miso/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/andreas311/miso/global/error/exception/ErrorCode.kt
@@ -11,7 +11,7 @@ enum class ErrorCode(
     // MAIL
     EMAIL_SEND_FAIL(500, "사용자를 찾을 수 없습니다."),
 
-    //FILE
+    // FILE
     INVALID_FORMAT_FILE(400, "잘못된 형식의 파일입니다."),
     FILE_UPLOAD_FAIL(500, "파일 업로드에 실패했습니다."),
 

--- a/src/main/kotlin/andreas311/miso/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/andreas311/miso/global/security/SecurityConfig.kt
@@ -69,6 +69,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/recyclables/all").authenticated()
             .antMatchers(HttpMethod.POST, "/recyclables/process_image").authenticated()
 
+            .antMatchers(HttpMethod.POST, "/notification/save/{deviceToken}").authenticated()
+
             .anyRequest().denyAll()
             .and()
             .exceptionHandling()

--- a/src/main/kotlin/andreas311/miso/global/util/FcmUtil.kt
+++ b/src/main/kotlin/andreas311/miso/global/util/FcmUtil.kt
@@ -1,0 +1,33 @@
+package andreas311.miso.global.util
+
+import andreas311.miso.domain.notification.entity.data.NotificationAlarm
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import org.springframework.stereotype.Component
+
+@Component
+class FcmUtil {
+
+    private val firebaseInstance: FirebaseMessaging
+        get() = FirebaseMessaging.getInstance()
+
+    fun sendNotification(deviceToken: String, notificationAlarm: NotificationAlarm) {
+        val message = getMassageBuilderByNotification(notificationAlarm)
+            .setToken(deviceToken)
+            .build()
+        firebaseInstance.send(message)
+    }
+
+    private fun getMassageBuilderByNotification(notificationAlarm: NotificationAlarm) =
+        with(notificationAlarm) {
+            Message.builder()
+                .setNotification(
+                    Notification.builder()
+                        .setTitle(title)
+                        .setBody(content)
+                        .build()
+                )
+        }
+
+}

--- a/src/main/kotlin/andreas311/miso/global/util/UserUtil.kt
+++ b/src/main/kotlin/andreas311/miso/global/util/UserUtil.kt
@@ -17,10 +17,10 @@ class UserUtil(
         return fetchUserByEmail(email)
     }
 
-    fun fetchUserByEmail(email: String): User =
+    private fun fetchUserByEmail(email: String): User =
         userRepository.findByEmail(email) ?: throw UserNotFoundException()
 
-    fun fetchUserEmail(): String =
+    private fun fetchUserEmail(): String =
         when(val principal = SecurityContextHolder.getContext().authentication.principal) {
             is UserDetails -> (principal as AuthDetails).username
             else -> principal.toString()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,4 +66,8 @@ discord:
   webhook:
     url: ${WEBHOOK_URL}
 
-secret-url: ${SECRET_URL}
+ai:
+  url: ${AI_URL}
+
+fcm:
+  url: ${FCM_URL}


### PR DESCRIPTION
- FCM 푸시 알림 기능 구현
- FCM 토큰을 저장하는 api 추가 구현
- 문의사항 로직 수정 ( 문의 사항 작성 / 어드민이 해당 문의 사항을 채택, 비채택 -> 사용자에게 푸시 알림 전송 )
- 문의 사항 채택, 비채택 시 해당 사유를 추가로 입력하도록 변경