### PR TITLE
문의 사항 리스트 api 통합

### DIFF
--- a/src/main/kotlin/andreas311/miso/domain/inquiry/presentation/InquiryController.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/presentation/InquiryController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @RequestController("/inquiry")
 class InquiryController(
+    private val listInquiryService: ListInquiryService,
     private val writeInquiryService: WriteInquiryService,
     private val listMyInquiryService: ListMyInquiryService,
     private val detailInquiryService: DetailInquiryService,
@@ -43,6 +44,11 @@ class InquiryController(
     @GetMapping("/all")
     fun inquiryAll(): ResponseEntity<ListInquiryResponseDto> =
         listAllInquiryService.execute()
+            .let { ResponseEntity.status(HttpStatus.OK).body(it) }
+
+    @GetMapping("/list")
+    fun inquiryList(): ResponseEntity<ListInquiryResponseDto> =
+        listInquiryService.execute()
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 
     @GetMapping("/filter/{state}")

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/repository/InquiryRepository.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/repository/InquiryRepository.kt
@@ -9,7 +9,7 @@ interface InquiryRepository : CrudRepository<Inquiry, Long> {
 
     fun findAllByOrderByCreatedDateDesc(): List<Inquiry>
 
-    fun findByUserOrderByCreatedDateDesc(user: User): List<Inquiry>?
+    fun findByUserOrderByCreatedDateDesc(user: User): List<Inquiry>
 
     fun findAllByInquiryStatusOrderByCreatedDateDesc(inquiryStatus: InquiryStatus): List<Inquiry>
 

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/ListInquiryService.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/ListInquiryService.kt
@@ -1,0 +1,8 @@
+package andreas311.miso.domain.inquiry.service
+
+import andreas311.miso.domain.inquiry.presentation.data.response.ListInquiryResponseDto
+
+interface ListInquiryService {
+
+    fun execute(): ListInquiryResponseDto
+}

--- a/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/ListInquiryServiceImpl.kt
+++ b/src/main/kotlin/andreas311/miso/domain/inquiry/service/impl/ListInquiryServiceImpl.kt
@@ -1,0 +1,32 @@
+package andreas311.miso.domain.inquiry.service.impl
+
+import andreas311.miso.domain.inquiry.presentation.data.response.InquiryResponseDto
+import andreas311.miso.domain.inquiry.presentation.data.response.ListInquiryResponseDto
+import andreas311.miso.domain.inquiry.repository.InquiryRepository
+import andreas311.miso.domain.inquiry.service.ListInquiryService
+import andreas311.miso.domain.user.enums.Role
+import andreas311.miso.global.annotation.ReadOnlyService
+import andreas311.miso.global.util.UserUtil
+
+@ReadOnlyService
+class ListInquiryServiceImpl(
+    private val userUtil: UserUtil,
+    private val inquiryRepository: InquiryRepository
+) : ListInquiryService {
+
+    override fun execute(): ListInquiryResponseDto {
+
+        val user = userUtil.currentUser()
+
+        val inquiry =
+            if (user.role.equals(Role.ROLE_USER)) {
+                inquiryRepository.findByUserOrderByCreatedDateDesc(user)
+            } else {
+                inquiryRepository.findAllByOrderByCreatedDateDesc()
+            }
+
+        return ListInquiryResponseDto(
+            inquiryList = inquiry.map { InquiryResponseDto(it) }
+        )
+    }
+}

--- a/src/main/kotlin/andreas311/miso/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/andreas311/miso/global/security/SecurityConfig.kt
@@ -59,6 +59,7 @@ class SecurityConfig(
 
             .antMatchers(HttpMethod.POST, "/inquiry").authenticated()
             .antMatchers(HttpMethod.GET, "/inquiry").authenticated()
+            .antMatchers(HttpMethod.GET, "/inquiry/list").authenticated()
             .antMatchers(HttpMethod.GET, "/inquiry/all").hasAuthority("ROLE_ADMIN")
             .antMatchers(HttpMethod.GET, "/inquiry/filter/{state}").authenticated()
             .antMatchers(HttpMethod.GET, "/inquiry/{id}").authenticated()


### PR DESCRIPTION
- 기존에 사용하던 유저 Role 과 어드민 Role 에 따라 다르게 불러오던 api 를 통합
- api 사용 시 서버에서 Role 을 읽어와 각각 다른 반환값을 전달하게 수정